### PR TITLE
Update example YAML to use arrays for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Example usage:
     agents:
       queue: default
     plugins:
-      sgringwe/cloud-builder#be0dccd:
-        auth_file: /path/to/service_account_json_key
-        service_account: your_account@yourproject.iam.gserviceaccount.com
-        project: yourproject
-        config_file: cloudbuild.test.yaml # Defaults to 'cloudbuild.yaml'
+      - sgringwe/cloud-builder#be0dccd:
+          auth_file: /path/to/service_account_json_key
+          service_account: your_account@yourproject.iam.gserviceaccount.com
+          project: yourproject
+          config_file: cloudbuild.test.yaml # Defaults to 'cloudbuild.yaml'
 ```
 
 ## Requirements


### PR DESCRIPTION
Hi @sgringwe! 😊

Harriet from Buildkite here 👋🏻 We’ve [updated](https://buildkite.com/changelog/45-updated-syntax-for-using-plugins-in-your-pipeline-yaml) our recommended plugin syntax to use arrays instead of a map, to help ensure plugins are executed in the correct order with all agent versions.

This PR updates your readme example to be the new recommended syntax, and makes them pass the latest [plugin-linter](https://github.com/buildkite-plugins/buildkite-plugin-linter) checks.

Let me know if you have any questions! We’d love to get the readme updated so people use the new best-practice syntax.